### PR TITLE
Remove one line in app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,7 +44,6 @@ const download = async (song, url, song_name, singer_names, query_artwork) => {
       singer_names = singer_names.replace(" and ", ", ");
       singer_names = singer_names.replace(" et ", ", ");
       singer_names = singer_names.replace(" und ", ", ");
-      singer_names = singer_names.replace(" & ", ", ");
       //Search track informations using the Itunes library
       const searchOptions = new itunesAPI.ItunesSearchOptions({
         term: query_artwork, // All searches require a single string query.


### PR DESCRIPTION
Just removed the line that convert & by , because on the apple website there is no artists separated by a &.
I change this because on artists like Years & Years I get results for others artists with Years, Years in their album or track title.
This is not a Hacktoberfest Pull (too short and not very important in my opinion)
If anyone wants to add more separators in others language it would be great !

